### PR TITLE
Simplify Titles

### DIFF
--- a/project-rome-docs/commanding/index.md
+++ b/project-rome-docs/commanding/index.md
@@ -5,9 +5,11 @@ ms.topic: overview
 ms.custom: seodec2018
 ---
 
-# Initiate actions remotely using Commanding
+# Commanding
 
-The Commanding scenarios include cases in which an app on a local device initiates some action on a remote device. These include remote app launching, remote messaging, and the process of discovering and identifying remote systems to connect to. The actions taken by these target devices are covered in the [Hosting](../hosting/index.md) scenarios.
+Commanding allows you to initiate actions remotely using a local device. 
+
+Actions can include remote app launching, remote messaging, and the process of discovering and identifying remote systems to connect to. The actions taken by these target devices are covered in the [Hosting](../hosting/index.md) scenarios.
 
 To get started with Commanding scenarios on your client device, select your preferred development platform on the left navigation pane.
 

--- a/project-rome-docs/hosting/index.md
+++ b/project-rome-docs/hosting/index.md
@@ -9,7 +9,7 @@ ms.custom: seodec2018
 
 Use hosting to handle remote action requests on a local device.
 
-Hosting scenarios include cases such as app launch requests or app service messages from apps on remote devices. Hosting is the necessary counterpart of the [Commanding](../commanding/index.md) scenarios.
+Hosting includes scenarios like app launch requests or app service messages from apps on remote devices. Hosting is the necessary counterpart of the [Commanding](../commanding/index.md) scenarios.
 
 To get started with Hosting scenarios on your client device, select your preferred development platform on the left navigation pane.
 

--- a/project-rome-docs/hosting/index.md
+++ b/project-rome-docs/hosting/index.md
@@ -5,9 +5,11 @@ ms.topic: overview
 ms.custom: seodec2018
 ---
 
-# Handle remote action requests on a local device with Hosting
+# Hosting
 
-The Hosting scenarios include cases in which a local app receives and handles action requests, such as app launch requests or app service messages, from apps on remote devices. Hosting is the necessary counterpart of the [Commanding](../commanding/index.md) scenarios.
+Use hosting to handle remote action requests on a local device.
+
+Hosting scenarios include cases such as app launch requests or app service messages from apps on remote devices. Hosting is the necessary counterpart of the [Commanding](../commanding/index.md) scenarios.
 
 To get started with Hosting scenarios on your client device, select your preferred development platform on the left navigation pane.
 

--- a/project-rome-docs/nearby-sharing/index.md
+++ b/project-rome-docs/nearby-sharing/index.md
@@ -6,8 +6,8 @@ ms.topic: overview
 ms.custom: seodec2018
 ---
 
-# Send files or websites to other devices with Nearby Sharing
+# Nearby Sharing
 
-The [Nearby sharing](https://blogs.windows.com/windowsexperience/2018/06/18/windows-10-tip-how-to-start-using-nearby-sharing-with-the-windows-10-april-2018-update/#SpPj2lqAq22UdMVS.97) feature, powered by Project Rome, allows apps to easily send files or websites to nearby devices using Bluetooth or WiFi.
+[Nearby sharing](https://blogs.windows.com/windowsexperience/2018/06/18/windows-10-tip-how-to-start-using-nearby-sharing-with-the-windows-10-april-2018-update/#SpPj2lqAq22UdMVS.97) allows apps to send files or websites to nearby devices using Bluetooth or WiFi.
 
 To get started with Nearby sharing on your device, select your preferred development platform on the left navigation pane.

--- a/project-rome-docs/remote-sessions/index.md
+++ b/project-rome-docs/remote-sessions/index.md
@@ -6,6 +6,10 @@ ms.topic: overview
 ms.custom: seodec2018
 ---
 
-# Connect to other devices through a session using Remote Sessions
+# Remote Sessions
 
-The Remote sessions feature allows an app to connect to other devices through a session, either for explicit app-to-app messaging or for brokered exchange of system-managed data. Sessions can be created by any device on a supported platform, and other devices, including devices signed in by other users, can request to join.
+The Remote sessions feature allows an app to connect to other devices through a session.
+
+Remote sessions can be used for explicit app-to-app messaging or for brokered exchange of system-managed data.
+
+Sessions can be created by any device on a supported platform, and other devices, including devices signed in by other users, can request to join.

--- a/project-rome-docs/user-activities/index.md
+++ b/project-rome-docs/user-activities/index.md
@@ -8,6 +8,8 @@ ms.custom: seodec2018
 
 # Create and publish user activities
 
-The User Activities feature allows apps to create and publish Windows-style User Activities. These are cloud based constructs that track the state of a user's tasks in an app. Activities can then be viewed and resumed at a later time, even across different devices and platforms. For more information on User Activities, see [Continue user activity, even across devices (UWP)](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities).
+The User Activities feature allows apps to create and publish Windows-style User Activities.
+
+User Activities are cloud based constructs that track the state of a user's tasks in an app. Activities can be viewed and resumed at a later time, even across different devices and platforms. For more information on User Activities, see [Continue user activity, even across devices (UWP)](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities).
 
 To get started with User Activities on your device, select your preferred development platform on the left navigation pane.


### PR DESCRIPTION
Add one sentence summary at beginning of page instead of verbose headings. 