### PR TITLE
Adding Windows how-to pages

### DIFF
--- a/project-rome-docs/TOC.md
+++ b/project-rome-docs/TOC.md
@@ -1,8 +1,7 @@
 # [Project Rome docs](index.md)
 
 ## [Device Relay](devicerelay/index.md)
-### [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/connected-apps-and-devices)
-### [API reference for Windows](https://docs.microsoft.com/uwp/api/Windows.System.RemoteSystems)
+### [How to guide for Windows](devicerelay/how-to-guide-for-windows.md)
 ### [How to guide for Android](devicerelay/how-to-guide-for-android.md)
 ### [API reference for Android](devicerelay/api-reference-for-android.md)
 ### [How to guide for iOS](devicerelay/how-to-guide-for-ios.md)
@@ -10,8 +9,7 @@
 ### [How to guide for Microsoft Graph](devicerelay/how-to-guide-for-microsoft-graph.md)
 
 ## [User Activities](user-activities/index.md)
-### [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities)
-### [API reference for Windows](https://docs.microsoft.com/uwp/api/windows.applicationmodel.useractivities)
+### [How to guide for Windows](user-activities/how-to-guide-for-windows.md)
 ### [How to guide for Android](user-activities/how-to-guide-for-android.md)
 ### [API reference for Android](user-activities/api-reference-for-android.md)
 ### [How to guide for iOS](user-activities/how-to-guide-for-ios.md)
@@ -30,8 +28,7 @@
 ### [Sending notifications using MS Graph APIs](notifications/sending-notifications.md)
 
 ## [Remote sessions](remote-sessions/index.md)
-### [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/remote-sessions)
-### [API reference for Windows](https://docs.microsoft.com/uwp/api/windows.system.remotesystems.remotesystemsession)
+### [How to guide for Windows](remote-sessions/how-to-guide-for-windows.md)
 
 ## [Nearby sharing](nearby-sharing/index.md)
 ### [API reference for Android](nearby-sharing/api-reference-for-android.md)

--- a/project-rome-docs/TOC.md
+++ b/project-rome-docs/TOC.md
@@ -1,19 +1,19 @@
 # [Project Rome docs](index.md)
 
 ## [Device Relay](devicerelay/index.md)
-### [How to guide for Windows](devicerelay/how-to-guide-for-windows.md)
 ### [How to guide for Android](devicerelay/how-to-guide-for-android.md)
 ### [API reference for Android](devicerelay/api-reference-for-android.md)
 ### [How to guide for iOS](devicerelay/how-to-guide-for-ios.md)
 ### [API reference for iOS](devicerelay/api-reference-for-ios.md)
+### [How to guide for Windows](devicerelay/how-to-guide-for-windows.md)
 ### [How to guide for Microsoft Graph](devicerelay/how-to-guide-for-microsoft-graph.md)
 
 ## [User Activities](user-activities/index.md)
-### [How to guide for Windows](user-activities/how-to-guide-for-windows.md)
 ### [How to guide for Android](user-activities/how-to-guide-for-android.md)
 ### [API reference for Android](user-activities/api-reference-for-android.md)
 ### [How to guide for iOS](user-activities/how-to-guide-for-ios.md)
 ### [API reference for iOS](user-activities/api-reference-for-ios.md)
+### [How to guide for Windows](user-activities/how-to-guide-for-windows.md)
 ### [How to guide for Microsoft Graph](user-activities/how-to-guide-for-microsoft-graph.md)
 
 ## [Notifications](notifications/index.md)

--- a/project-rome-docs/devicerelay/how-to-guide-for-microsoft-graph.md
+++ b/project-rome-docs/devicerelay/how-to-guide-for-microsoft-graph.md
@@ -1,6 +1,5 @@
+# Using Microsoft Graph's Device Relay REST APIs
 
-# Microsoft Graph Commanding APIs
+Device Relay features can be implemented through REST API calls with Microsoft Graph. You can find more information and API reference documentation in the [Project Rome section of the Microsoft Graph docs](https://developer.microsoft.com/graph/docs/api-reference/beta/resources/project_rome_overview#devices).
 
-Device Relay features can be implemented through REST API calls with Microsoft Graph. This allows you to discover your devices, launch apps, and interact with app services from any device capable of making HTTP requests. Microsoft Graph makes these scenarios simpler to implement than on the native platform SDKs, but it does not support all of the features Project Rome features or offer a native object model.
-
-You can find more information and API reference documentation in the [Project Rome section of the Microsoft Graph docs](https://developer.microsoft.com/graph/docs/api-reference/beta/resources/project_rome_overview#devices).
+Implementing with Microsoft Graph allows you to discover your devices, launch apps, and interact with app services from any device capable of making HTTP requests. Microsoft Graph makes these scenarios simpler to implement than on the native platform SDKs, but it does not support all of the features Project Rome features or offer a native object model.

--- a/project-rome-docs/devicerelay/how-to-guide-for-windows.md
+++ b/project-rome-docs/devicerelay/how-to-guide-for-windows.md
@@ -1,0 +1,6 @@
+# Using Windows to implement Device Relay
+
+The how-to and API reference pages for Device Relay for Windows apps are kept in the UWP docs pages. Check out the following articles to learn how to implement Device Relay for Windows apps:
+
+[How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/connected-apps-and-devices)
+[API reference for Windows](https://docs.microsoft.com/uwp/api/Windows.System.RemoteSystems)

--- a/project-rome-docs/devicerelay/how-to-guide-for-windows.md
+++ b/project-rome-docs/devicerelay/how-to-guide-for-windows.md
@@ -1,6 +1,7 @@
 # Using Windows to implement Device Relay
 
-The how-to and API reference pages for Device Relay for Windows apps are kept in the UWP docs pages. Check out the following articles to learn how to implement Device Relay for Windows apps:
+The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement Device Relay for Windows apps:
 
 [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/connected-apps-and-devices)
+
 [API reference for Windows](https://docs.microsoft.com/uwp/api/Windows.System.RemoteSystems)

--- a/project-rome-docs/devicerelay/how-to-guide-for-windows.md
+++ b/project-rome-docs/devicerelay/how-to-guide-for-windows.md
@@ -1,4 +1,4 @@
-# Using Windows to implement Device Relay
+# Implementing Device Relay for Windows
 
 The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement Device Relay for Windows apps:
 

--- a/project-rome-docs/devicerelay/index.md
+++ b/project-rome-docs/devicerelay/index.md
@@ -7,7 +7,7 @@ ms.custom: seodec2018
 
 # Device Relay
 
-Device Relay allows you to command or initiate actions remotely using a local device. 
+Device Relay allows you to command or initiate actions remotely using a local device.
 
 Actions can include remote app launching, remote messaging, and the process of discovering and identifying remote systems to connect to.
 

--- a/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
+++ b/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
@@ -3,4 +3,5 @@
 The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement Remote Sessions for Windows apps:
 
 [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/remote-sessions)
+
 [API reference for Windows](https://docs.microsoft.com/uwp/api/windows.system.remotesystems.remotesystemsession)

--- a/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
+++ b/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
@@ -1,6 +1,6 @@
 # Using Windows to implement Remote Sessions
 
-The how-to and API reference pages for Remote Sessions for Windows apps are kept in the UWP docs pages. Check out the following articles to learn how to implement Remote Sessions for Windows apps:
+The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement Remote Sessions for Windows apps:
 
 [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/remote-sessions)
 [API reference for Windows](https://docs.microsoft.com/uwp/api/windows.system.remotesystems.remotesystemsession)

--- a/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
+++ b/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
@@ -1,4 +1,4 @@
-# Using Windows to implement Remote Sessions
+# Implementing Remote Sessions for Windows
 
 The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement Remote Sessions for Windows apps:
 

--- a/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
+++ b/project-rome-docs/remote-sessions/how-to-guide-for-windows.md
@@ -1,0 +1,6 @@
+# Using Windows to implement Remote Sessions
+
+The how-to and API reference pages for Remote Sessions for Windows apps are kept in the UWP docs pages. Check out the following articles to learn how to implement Remote Sessions for Windows apps:
+
+[How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/remote-sessions)
+[API reference for Windows](https://docs.microsoft.com/uwp/api/windows.system.remotesystems.remotesystemsession)

--- a/project-rome-docs/user-activities/how-to-guide-for-android.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-android.md
@@ -7,7 +7,7 @@ ms.assetid: 8cfb7544-913c-48c0-8528-52b93ba8b0c6
 ms.localizationpriority: medium
 ---
 
-# Publishing and reading User Activities
+# Implementing User Activities for Android
 
 User Activities are data constructs that represent a user's tasks within an application. They make it possible to save a snapshot of a task to be continued at a later time. The [Windows Timeline](https://blogs.windows.com/windowsexperience/2018/04/27/make-the-most-of-your-time-with-the-new-windows-10-update/) feature presents Windows users with a scrollable list of all their recent activities, represented as cards with text and graphics. For more information about User Activities in general, see [Continue user activity, even across devices](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities). For recommendations on when to create or update Activities, see the [User Activities best practices](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities-best-practices) guide.
 

--- a/project-rome-docs/user-activities/how-to-guide-for-ios.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-ios.md
@@ -7,7 +7,7 @@ ms.assetid: 445f1dd4-f3c7-46e4-a7cd-42a1fb411172
 ms.localizationpriority: medium
 ---
 
-# Publishing and reading User Activities
+# Implementing User Activities for iOS
 
 User Activities are data constructs that represent a user's tasks within an application. They make it possible to save a snapshot of a current task to be continued at a later time. The [Windows Timeline](https://blogs.windows.com/windowsexperience/2018/04/27/make-the-most-of-your-time-with-the-new-windows-10-update/) feature presents Windows users with a scrollable list of all their recent activities, represented as cards with text and graphics. For more information about User Activities in general, see [Continue user activity, even across devices](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities). For recommendations on when to create or update Activities, see the [User Activities best practices](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities-best-practices) guide.
 

--- a/project-rome-docs/user-activities/how-to-guide-for-microsoft-graph.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-microsoft-graph.md
@@ -1,6 +1,5 @@
+# Using Microsoft Graph's User Activities REST APIs
 
-# Microsoft Graph User Activities APIs
+The User Activities feature can be implemented through REST API calls with Microsoft Graph. You can find more information and API reference documentation in the [Project Rome section of the Microsoft Graph docs](https://developer.microsoft.com/graph/docs/api-reference/beta/resources/project_rome_overview#activities).
 
-The User Activities feature can be implemented through REST API calls with Microsoft Graph. This allows you to create, publish, update, and read Windows-style User Activities from any device capable of making HTTP requests. Microsoft Graph makes these scenarios simpler to implement than on the native platform SDKs, but it does not support all of the Project Rome features or provide a native object model.
-
-You can find more information and API reference documentation in the [Project Rome section of the Microsoft Graph docs](https://developer.microsoft.com/graph/docs/api-reference/beta/resources/project_rome_overview#activities).
+This allows you to create, publish, update, and read Windows-style User Activities from any device capable of making HTTP requests. Microsoft Graph makes these scenarios simpler to implement than on the native platform SDKs, but it does not support all of the Project Rome features or provide a native object model.

--- a/project-rome-docs/user-activities/how-to-guide-for-windows.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-windows.md
@@ -1,4 +1,4 @@
-# Using Windows to implement User Activities
+# Implementing User Activities for Windows
 
 The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement User Activities for Windows apps:
 

--- a/project-rome-docs/user-activities/how-to-guide-for-windows.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-windows.md
@@ -1,0 +1,6 @@
+# Using Windows to implement User Activities
+
+The how-to and API reference pages for User Activities for Windows apps are kept in the UWP docs pages. Check out the following articles to learn how to implement User Activities for Windows apps:
+
+### [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities)
+### [API reference for Windows](https://docs.microsoft.com/uwp/api/windows.applicationmodel.useractivities)

--- a/project-rome-docs/user-activities/how-to-guide-for-windows.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-windows.md
@@ -1,6 +1,7 @@
 # Using Windows to implement User Activities
 
-The how-to and API reference pages for User Activities for Windows apps are kept in the UWP docs pages. Check out the following articles to learn how to implement User Activities for Windows apps:
+The Windows related how-to and API pages for Project Rome are included in the UWP section of the Microsoft docs site. Check out the following articles to learn how to implement User Activities for Windows apps:
 
-### [How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities)
-### [API reference for Windows](https://docs.microsoft.com/uwp/api/windows.applicationmodel.useractivities)
+[How to guide for Windows](https://docs.microsoft.com/windows/uwp/launch-resume/useractivities)
+
+[API reference for Windows](https://docs.microsoft.com/uwp/api/windows.applicationmodel.useractivities)


### PR DESCRIPTION
Added how-to pages for Windows to the Project Rome repo. This makes it so a user is no longer "teleported" to a different repo when s/he clicks on the Windows links in the TOC. 