### PR TITLE
Style: Remove extra comma to correct json format of .openpublishing.redirection.json

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -199,7 +199,6 @@
       "source_path": " project-rome-docs/user-activities/msgraph/index.md",
       "redirect_url": "https://docs.microsoft.com/windows/project-rome/user-activities/how-to-guide-for-microsoft-graph",
       "redirect_document_id": true
-    },
-    
+    }
   ]
 }


### PR DESCRIPTION
This fix is for docfx v3 migration and it won't break any of your published content pages.

The reason why we do this change is that the extra comma breaks json format of redirection config file and blocks ops build/publish