### PR TITLE
Linkfix: Project Rome (2021-06)

### DIFF
--- a/project-rome-docs/notifications/api-reference-for-android.md
+++ b/project-rome-docs/notifications/api-reference-for-android.md
@@ -10,5 +10,5 @@ The following namespaces contain APIs that allow an app to receive and manage Us
 ## Namespaces
 
 #### [ConnectedDevices](/java/api/com.microsoft.connecteddevices)
-#### [UserNotifications]( https://docs.microsoft.com/java/api/com.microsoft.connecteddevices.usernotifications)
+#### [UserNotifications](/java/api/com.microsoft.connecteddevices.usernotifications)
 #### [UserData](/java/api/com.microsoft.connecteddevices.userdata)


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```