### PR TITLE
Bulk fix - Removing .localizationpriority

### DIFF
--- a/project-rome-docs/devicerelay/how-to-guide-for-android.md
+++ b/project-rome-docs/devicerelay/how-to-guide-for-android.md
@@ -4,7 +4,6 @@ description: This guide will show how to discover remote devices and apps and th
 ms.topic: article
 keywords: microsoft, windows, project rome, commanding, android
 ms.assetid: 2fd14dd0-0f1f-49ee-83e3-468737810c81
-ms.localizationpriority: medium
 ---
 
 # Implementing device relay for Android

--- a/project-rome-docs/devicerelay/how-to-guide-for-ios.md
+++ b/project-rome-docs/devicerelay/how-to-guide-for-ios.md
@@ -4,7 +4,6 @@ description: This guide will show how to discover remote devices and apps and th
 ms.topic: article
 keywords: microsoft, windows, project rome, commanding, ios
 ms.assetid: b5d426db-a0ca-4888-b2cb-cb7fdb1c6c0d
-ms.localizationpriority: medium
 ---
 
 # Implementing device relay for iOS

--- a/project-rome-docs/includes/android/create-setup-events-platform.md
+++ b/project-rome-docs/includes/android/create-setup-events-platform.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 
-ms.localizationpriority: medium
 ---
 
 ### Create the platform

--- a/project-rome-docs/includes/android/create-setup-events-start-platform.md
+++ b/project-rome-docs/includes/android/create-setup-events-start-platform.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 
-ms.localizationpriority: medium
 ---
 
 ### Create the platform

--- a/project-rome-docs/includes/android/dev-center-onboarding.md
+++ b/project-rome-docs/includes/android/dev-center-onboarding.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: dc4d7bbd-bc87-42b1-9924-52c7bfcd5b5f
-ms.localizationpriority: medium
 ---
 
 ## Preliminary setup for push notifications

--- a/project-rome-docs/includes/android/notification-init.md
+++ b/project-rome-docs/includes/android/notification-init.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: fcbcfd8f-6eea-421a-97bb-31ea3c987728
-ms.localizationpriority: medium
 ---
 
 ## Preliminary setup for push notifications

--- a/project-rome-docs/includes/android/notifications-app-registration-onboarding.md
+++ b/project-rome-docs/includes/android/notifications-app-registration-onboarding.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: bbef84bf-a6b7-44be-879d-0fa6065e37b1
-ms.localizationpriority: medium
 ---
 
 ### MSA and AAD Authentication Registration

--- a/project-rome-docs/includes/android/notifications-dev-center-onboarding.md
+++ b/project-rome-docs/includes/android/notifications-dev-center-onboarding.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: dc4d7bbd-bc87-42b1-9924-52c7bfcd5b5f
-ms.localizationpriority: medium
 ---
 
 ### Register your app for push notifications

--- a/project-rome-docs/includes/android/notifications-notification-init.md
+++ b/project-rome-docs/includes/android/notifications-notification-init.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 9fb27596-e9a3-443a-9c12-9e02a893e32c
-ms.localizationpriority: medium
 ---
 
 

--- a/project-rome-docs/includes/android/notifications-platfrom-init.md
+++ b/project-rome-docs/includes/android/notifications-platfrom-init.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 9f679e13-b1b3-40f8-bd44-679e4dffc0d4
-ms.localizationpriority: medium
 ---
 
 ### Add the SDK

--- a/project-rome-docs/includes/android/preliminary-setup.md
+++ b/project-rome-docs/includes/android/preliminary-setup.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 
-ms.localizationpriority: medium
 ---
 
 ## Preliminary setup for the Connected Devices Platform and Notifications

--- a/project-rome-docs/includes/android/preliminary-setupActivities.md
+++ b/project-rome-docs/includes/android/preliminary-setupActivities.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 
-ms.localizationpriority: medium
 ---
 
 ## Preliminary setup for the Connected Devices Platform

--- a/project-rome-docs/includes/auth-scopes.md
+++ b/project-rome-docs/includes/auth-scopes.md
@@ -2,7 +2,6 @@
 title: include file
 description: include file
 ms.assetid: 93f45482-14e4-4aec-8185-ee05b592215f
-ms.localizationpriority: medium
 ---
 
 ### Set up authentication and account management

--- a/project-rome-docs/includes/auth-scopesiOS.md
+++ b/project-rome-docs/includes/auth-scopesiOS.md
@@ -2,7 +2,6 @@
 title: include file
 description: include file
 ms.assetid: 93f45482-14e4-4aec-8185-ee05b592215f
-ms.localizationpriority: medium
 ---
 
 ### Set up authentication and account management

--- a/project-rome-docs/includes/ios/create-setup-events-start-platform.md
+++ b/project-rome-docs/includes/ios/create-setup-events-start-platform.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 
-ms.localizationpriority: medium
 ---
 
 ### Create an instance of the platform

--- a/project-rome-docs/includes/ios/dev-center-onboarding.md
+++ b/project-rome-docs/includes/ios/dev-center-onboarding.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 0741073e-62de-4e31-8e3b-cd1a55027c1c
-ms.localizationpriority: medium
 ---
 
 ## Preliminary setup for push notifications

--- a/project-rome-docs/includes/ios/notification-init.md
+++ b/project-rome-docs/includes/ios/notification-init.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 195e419e-ac8d-4e96-8faa-c3659570fa27
-ms.localizationpriority: medium
 ---
 
 ## Preliminary setup for push notifications

--- a/project-rome-docs/includes/ios/notifications-app-registration-onboarding.md
+++ b/project-rome-docs/includes/ios/notifications-app-registration-onboarding.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 771ceeb1-638f-4fba-8c34-953870b5d855
-ms.localizationpriority: medium
 ---
 
 ### MSA and AAD Authentication Registration

--- a/project-rome-docs/includes/ios/notifications-dev-center-onboarding.md
+++ b/project-rome-docs/includes/ios/notifications-dev-center-onboarding.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 0741073e-62de-4e31-8e3b-cd1a55027c1c
-ms.localizationpriority: medium
 ---
 
 ### Register your app for push notifications

--- a/project-rome-docs/includes/ios/notifications-notification-init.md
+++ b/project-rome-docs/includes/ios/notifications-notification-init.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 30df8538-1c1f-498f-af25-0be0aed687c8
-ms.localizationpriority: medium
 ---
 
 ### TODO Configure your app to be APNs notification-compatible

--- a/project-rome-docs/includes/ios/notifications-platform-init.md
+++ b/project-rome-docs/includes/ios/notifications-platform-init.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: cf4bc236-1a9c-4192-b3fe-2d78331316c0
-ms.localizationpriority: medium
 ---
 
 ### Add the SDK

--- a/project-rome-docs/includes/ios/preliminary-setup.md
+++ b/project-rome-docs/includes/ios/preliminary-setup.md
@@ -3,7 +3,6 @@ title: include file
 description: include file
 ms.topic: include
 ms.assetid: 
-ms.localizationpriority: medium
 ---
 
 ### Register your app

--- a/project-rome-docs/nearby-sharing/index.md
+++ b/project-rome-docs/nearby-sharing/index.md
@@ -1,7 +1,6 @@
 ---
 title: Send Files to Nearby Devices - Nearby Sharing
 description: Learn about Nearby Sharing. Nearby Sharing is used to send files or websites to nearby devices using Bluetooth or WiFi.
-ms.localizationpriority: medium
 ms.topic: overview
 ms.custom: seodec2018
 ---

--- a/project-rome-docs/notifications/how-to-guide-for-android.md
+++ b/project-rome-docs/notifications/how-to-guide-for-android.md
@@ -2,7 +2,6 @@
 title: Integrating Android apps with Graph Notifications
 description: How to perform the necessary registration steps to become a receiving endpoint for notifications published from your app server.
 ms.assetid: c973d534-08e9-4f6e-8b54-bcae97067961
-ms.localizationpriority: medium
 ms.custom: seodec18
 ---
 

--- a/project-rome-docs/notifications/how-to-guide-for-ios.md
+++ b/project-rome-docs/notifications/how-to-guide-for-ios.md
@@ -2,7 +2,6 @@
 title: Integrating IOs Apps with Graph Notifications
 description: How to perform the necessary registration steps to become a receiving endpoint for notifications published from your app server.
 ms.assetid: c973d534-08e9-4f6e-8b54-bcae97067961
-ms.localizationpriority: medium
 ms.custom: seodec18
 ---
 

--- a/project-rome-docs/notifications/how-to-guide-for-windows.md
+++ b/project-rome-docs/notifications/how-to-guide-for-windows.md
@@ -2,7 +2,6 @@
 title: Integrating UWP Apps with Graph Notifications
 description: How to perform the necessary registration steps to become a receiving endpoint for notifications published from your app server.
 ms.assetid: c973d534-08e9-4f6e-8b54-bcae97067961
-ms.localizationpriority: medium
 ms.custom: seodec18
 ---
 

--- a/project-rome-docs/notifications/index.md
+++ b/project-rome-docs/notifications/index.md
@@ -1,7 +1,6 @@
 ---
 title: Microsoft Graph Notifications
 description: Include Microsoft Graph notifications in your application to re-engage users in a human-centric way.
-ms.localizationpriority: medium
 ms.topic: overview
 ms.custom: seodec2018
 ---

--- a/project-rome-docs/notifications/sending-notifications.md
+++ b/project-rome-docs/notifications/sending-notifications.md
@@ -2,7 +2,6 @@
 title: Sending notifications using Microsoft Graph APIs
 description: Integrate your apps with Microsoft Graph notifications in a few simple steps.
 ms.assetid: 8ff9cd93-a48e-4198-927f-3d7bd4b65f29
-ms.localizationpriority: medium
 ms.custom: seodec18
 ---
 

--- a/project-rome-docs/remote-sessions/index.md
+++ b/project-rome-docs/remote-sessions/index.md
@@ -1,7 +1,6 @@
 ---
 title: Connect to Another Device via Remote Session
 description: Learn how to use a session to connect your local app to a remote device. Remote sessions can be used for explicit app-to-app messaging.
-ms.localizationpriority: medium
 ms.topic: overview
 ms.custom: seodec2018
 ---

--- a/project-rome-docs/user-activities/how-to-guide-for-android.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-android.md
@@ -4,7 +4,6 @@ description: This guide shows how to create, publish, and read Windows-based Use
 ms.topic: article
 keywords: microsoft, windows, project rome, user activities, android
 ms.assetid: 8cfb7544-913c-48c0-8528-52b93ba8b0c6
-ms.localizationpriority: medium
 ---
 
 # Implementing User Activities for Android

--- a/project-rome-docs/user-activities/how-to-guide-for-ios.md
+++ b/project-rome-docs/user-activities/how-to-guide-for-ios.md
@@ -4,7 +4,6 @@ description: This guide shows how to create, publish, and read Windows-based Use
 ms.topic: article
 keywords: microsoft, windows, project rome, user activities, ios
 ms.assetid: 445f1dd4-f3c7-46e4-a7cd-42a1fb411172
-ms.localizationpriority: medium
 ---
 
 # Implementing User Activities for iOS

--- a/project-rome-docs/user-activities/index.md
+++ b/project-rome-docs/user-activities/index.md
@@ -1,7 +1,6 @@
 ---
 title: Create and Publish User Activities
 description: Learn how to create and publish Windows-style user activities. User Activities are cloud-based constructs that track the state of a user's tasks in an app.
-ms.localizationpriority: medium
 ms.topic: overview
 ms.custom: seodec2018
 ---


### PR DESCRIPTION
This is a bulk fix - According to the new DevRel GX group mission, the Localization production team drives the localization priority and translation quality per customer usage data, e.g. Page View or MAU of the language. The localization priority is defined by the project setting in localization pipeline - ms.localizationpriority in the source file is no longer used as a driving parameter to define the localization priority. https://review.docs.microsoft.com/help/contribute/localization-checklist-for-writer?branch=master#stop-using-mslocalizationpriority-metadata