### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/project-rome-docs/includes/android/notifications-platfrom-init.md
+++ b/project-rome-docs/includes/android/notifications-platfrom-init.md
@@ -27,7 +27,7 @@ dependencies {
 }
 ```
 
-If you wish to use ProGuard in your app, add the ProGuard Rules for these new APIs. Create a file called *proguard-rules.txt* in the *App* folder of your project, and paste in the contents of [ProGuard_Rules_for_Android_Rome_SDK.txt](https://github.com/Microsoft/project-rome/blob/master/Android/ProGuard_Rules_for_Android_Rome_SDK.txt).
+If you wish to use ProGuard in your app, add the ProGuard Rules for these new APIs. Create a file called *proguard-rules.txt* in the *App* folder of your project, and paste in the contents of ProGuard_Rules_for_Android_Rome_SDK.txt.
 
 In your project's *AndroidManifest.xml* file, add the following permissions inside the `<manifest>` element (if they are not already present). This gives your app permission to connect to the Internet and to enable Bluetooth discovery on your device.
 


### PR DESCRIPTION
Removed broken link related to ProGuard_Rules_for_Android_Rome_SDK.txt, the file does not exist anymore in GitHub.